### PR TITLE
Improve layout spacing for better mobile experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,14 +65,16 @@
     }
     .main-content {
       min-height: 100vh;
+      width: min(100%, 960px);
+      margin: 0 auto;
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       position: relative;
       z-index: 2;
-      padding: 0 2vw;
-      gap: 0;
+      padding: clamp(3rem, 8vh, 4.5rem) clamp(1.5rem, 5vw, 3rem) clamp(8rem, 14vh, 10rem);
+      gap: clamp(1.5rem, 4vh, 2.5rem);
     }
     .main-content > * {
       opacity: 0;
@@ -161,16 +163,19 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 1.5em;
+      gap: 1.2em;
+      row-gap: 0.8em;
+      flex-wrap: wrap;
       background: rgba(255,255,255,0.13);
       border-radius: 48px;
       box-shadow: 0 4px 32px rgba(0,0,0,0.10);
-      padding: 1.2em 2.2em;
+      padding: 1.2em clamp(1.4em, 6vw, 2.5em);
       margin-top: 1.5em;
       margin-bottom: 1.5em;
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
       border: 2px solid rgba(255,255,255,0.18);
+      max-width: min(100%, 640px);
     }
     .main-btn {
       display: flex;
@@ -291,7 +296,7 @@
     }
     .social-feed-card {
       margin: 2.5em auto 0 auto;
-      max-width: 1100px;
+      max-width: min(1100px, 100%);
       background: linear-gradient(120deg, rgba(34,43,58,0.55) 60%, rgba(16,23,42,0.38) 100%);
       border-radius: 32px;
       box-shadow: 0 6px 32px rgba(0,0,0,0.18);
@@ -389,7 +394,12 @@
       .social-feed-item { padding: 0.7em 0.2em 0.8em 0.2em; }
     }
     @media (max-width: 500px) {
-      .main-content { padding: 0 2vw; }
+      .main-content {
+        width: 100%;
+        padding: 4.5rem 1.2rem 7.5rem;
+        align-items: stretch;
+        gap: 1.3rem;
+      }
       .profile-img-hex {
         width: 90px;
         height: 102px;
@@ -401,7 +411,14 @@
       }
       .name { font-size: 1.2em; }
       .bio { font-size: 0.85em; padding: 0 0.2em; }
-      .actions { flex-direction: row; gap: 0.5em; padding: 0.7em 0.2em; justify-content: center; }
+      .actions {
+        flex-direction: row;
+        gap: 0.6em;
+        row-gap: 0.6em;
+        padding: 0.7em 0.6em;
+        justify-content: center;
+        border-radius: 28px;
+      }
       .profile-row { flex-direction: column; gap: 0.5em; }
       .icon-btn { width: 32px; height: 32px; font-size: 0.9em; }
       .about-card, .social-feed-card, .quote-card {
@@ -410,6 +427,22 @@
         font-size: 0.85em;
       }
       .quote-icon { width: 1em; height: 1em; }
+    }
+
+    @media (max-width: 900px) {
+      .main-content {
+        padding: clamp(2.5rem, 6vh, 3.5rem) clamp(1.2rem, 5vw, 2.5rem) clamp(7rem, 18vh, 9rem);
+        width: 100%;
+      }
+      .bio {
+        max-width: 100%;
+      }
+    }
+
+    @media (min-width: 1200px) {
+      .main-content {
+        padding-bottom: 8rem;
+      }
     }
     .profile-row {
       display: flex;


### PR DESCRIPTION
## Summary
- adjust the main layout spacing so content can flow naturally on narrow screens
- allow social action buttons to wrap and shrink padding to avoid overflow
- widen responsive padding rules so cards and biography text fill the screen on phones

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7ea8e64548331a12f46eca9dafb09