### PR TITLE
Adjust profile image layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,10 +70,10 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: flex-start;
+      justify-content: center;
       position: relative;
       z-index: 2;
-      padding: clamp(3rem, 8vh, 4.5rem) clamp(1.5rem, 5vw, 3rem) clamp(8rem, 14vh, 10rem);
+      padding: clamp(2.5rem, 6vh, 3.5rem) clamp(1.5rem, 5vw, 3rem);
       gap: clamp(1.5rem, 4vh, 2.5rem);
     }
     .main-content > * {
@@ -95,8 +95,8 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      width: 320px;
-      height: 364px;
+      width: clamp(320px, 32vw, 420px);
+      height: clamp(364px, 36vw, 480px);
       background: #fff;
       clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
       -webkit-clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
@@ -109,8 +109,8 @@
       filter: brightness(1.08) drop-shadow(0 0 16px #7be86c88);
     }
     .profile-img {
-      width: 288px;
-      height: 328px;
+      width: clamp(288px, 28vw, 380px);
+      height: clamp(328px, 32vw, 432px);
       border-radius: 0;
       object-fit: cover;
       object-position: center top;


### PR DESCRIPTION
## Summary
- enlarge the profile photo within its hexagonal frame and make it responsive
- center the main content vertically for a balanced layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ece8ebc483319db4d57aa424c55c