### PR TITLE
Profil sayfası: içerik, erişilebilirlik ve "Şu Sıra" bölümü

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,9 +117,9 @@
         <h1 class="hero__name">Önder<br><span class="hero__name--accent">GÖG</span></h1>
 
         <p class="hero__bio"
-           data-tr="iOS, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum."
-           data-en="I build small automation tools and personal projects with iOS, Python and PowerShell.">
-          iOS, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum.
+           data-tr="Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum."
+           data-en="I build small automation tools and personal projects with Python and PowerShell.">
+          Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum.
         </p>
         <p class="hero__bio hero__bio--secondary"
            data-tr="İş dışında snowboard, motosiklet, doğa; kulağımda techno ve Anadolu rock."

--- a/index.html
+++ b/index.html
@@ -201,9 +201,9 @@
         </li>
         <li class="now-item">
           <span class="now-item__dot" aria-hidden="true"></span>
-          <p data-tr="iOS ve Windows için küçük otomasyon betikleri yazıyorum."
-             data-en="Writing small automation scripts for iOS and Windows.">
-            iOS ve Windows için küçük otomasyon betikleri yazıyorum.
+          <p data-tr="Windows için küçük otomasyon betikleri yazıyorum."
+             data-en="Writing small automation scripts for Windows.">
+            Windows için küçük otomasyon betikleri yazıyorum.
           </p>
         </li>
         <li class="now-item">

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0a0a0a" />
   <title>Önder GÖG | Kişisel Web Sitesi</title>
-  <meta name="description" content="Önder GÖG — Bursa'da yaşayan, teknoloji ve yazılımla ilgilenen biri. Android, Python, PowerShell ve daha fazlası." />
+  <meta name="description" content="Önder GÖG — Bursa'da yaşayan, teknoloji ve yazılımla ilgilenen biri. iOS, Python, PowerShell ve daha fazlası." />
   <meta name="author" content="Önder GÖG" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://bygog.github.io/" />
   <meta property="og:title" content="Önder GÖG | Kişisel Web Sitesi" />
-  <meta property="og:description" content="Önder GÖG — Bursa'da yaşayan, teknoloji ve yazılımla ilgilenen biri. Android, Python, PowerShell ve daha fazlası." />
+  <meta property="og:description" content="Önder GÖG — Bursa'da yaşayan, teknoloji ve yazılımla ilgilenen biri. iOS, Python, PowerShell ve daha fazlası." />
   <meta property="og:image" content="https://bygog.github.io/profil-opt.jpg" />
   <meta property="og:locale" content="tr_TR" />
 
@@ -117,9 +117,9 @@
         <h1 class="hero__name">Önder<br><span class="hero__name--accent">GÖG</span></h1>
 
         <p class="hero__bio"
-           data-tr="Android, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum."
-           data-en="I build small automation tools and personal projects with Android, Python and PowerShell.">
-          Android, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum.
+           data-tr="iOS, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum."
+           data-en="I build small automation tools and personal projects with iOS, Python and PowerShell.">
+          iOS, Python ve PowerShell ile küçük otomasyon araçları ve kişisel projeler geliştiriyorum.
         </p>
         <p class="hero__bio hero__bio--secondary"
            data-tr="İş dışında snowboard, motosiklet, doğa; kulağımda techno ve Anadolu rock."
@@ -131,7 +131,7 @@
           <div class="hero__tag-group">
             <span class="hero__tag-label" data-tr="Platform" data-en="Platforms">Platform</span>
             <ul class="hero__tags">
-              <li>Android</li>
+              <li>iOS</li>
               <li>Windows</li>
             </ul>
           </div>
@@ -201,9 +201,9 @@
         </li>
         <li class="now-item">
           <span class="now-item__dot" aria-hidden="true"></span>
-          <p data-tr="Android ve Windows için küçük otomasyon betikleri yazıyorum."
-             data-en="Writing small automation scripts for Android and Windows.">
-            Android ve Windows için küçük otomasyon betikleri yazıyorum.
+          <p data-tr="iOS ve Windows için küçük otomasyon betikleri yazıyorum."
+             data-en="Writing small automation scripts for iOS and Windows.">
+            iOS ve Windows için küçük otomasyon betikleri yazıyorum.
           </p>
         </li>
         <li class="now-item">
@@ -316,7 +316,7 @@
       "addressLocality": "Bursa",
       "addressCountry": "TR"
     },
-    "knowsAbout": ["Android", "Windows", "Python", "PowerShell", "HTML", "CSS", "Git"]
+    "knowsAbout": ["iOS", "Windows", "Python", "PowerShell", "HTML", "CSS", "Git"]
   }
   </script>
 


### PR DESCRIPTION
## Özet

Profil sayfasında içerik, erişilebilirlik ve görsel netlik üzerine bir grup iyileştirme:

- **Erişilebilirlik:** Skip-to-content linki + `<main>` sarmalaması
- **SEO/PWA:** Açık `<link rel="icon">` tanımları (192/512)
- **Hero:**
  - Eyebrow "Merhaba, ben" → **"Developer · Bursa, TR"**
  - Bio iki paragrafa ayrıldı: ne yapıyorum + kişisel ilgiler
  - Teknoloji etiketleri **"Platform"** (iOS, Windows) ve **"Araçlar"** (Python, PowerShell, HTML/CSS, Git) gruplarına ayrıldı
  - İki mail ikonu **`@y` / `@g`** harf etiketleriyle görsel olarak ayrıştırıldı
- **Yeni "Şu Sıra" bölümü** (now-page tarzı): 3 maddelik durum güncellemesi + son güncelleme tarihi
- **Bölüm numaralandırma:** 01 Şu Sıra, 02 Projeler, 03 İletişim
- **Platform güncellemesi:** Android → iOS (etiket, bio, meta/OG, JSON-LD)

## Test planı

- [ ] `index.html` tarayıcıda açıldığında hero, "Şu Sıra", projeler, iletişim sırayla görünüyor
- [ ] Tab tuşu ile skip-link öne çıkıyor ve `#main`'e atlıyor
- [ ] EN/TR dil değişiminde tüm yeni metinler doğru çevriliyor (eyebrow, bio2, tag-label'lar, "Şu Sıra" maddeleri, "Son güncelleme")
- [ ] Açık ve koyu temada "Şu Sıra" kartları ve `@y`/`@g` ikonları okunaklı
- [ ] Mobil (≤900px) görünümde tag grupları, ikinci bio paragrafı ve "Şu Sıra" listesi merkezde/düzgün hizalı
- [ ] `hero__scroll` artık `#simdi`'ye scroll ediyor